### PR TITLE
Added test cases for use with the work to handle IOExceptions

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.data.multiple.frames.partial.writes/client/source.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.data.multiple.frames.partial.writes/client/source.rpt
@@ -57,8 +57,6 @@ write [0x07] "client "
 write [0x00]
 write flush
 
-write notify SECOND_WRITE_COMPLETED
-
 read [0x40 0x00 0x00 0x02]
 read ${newSourceOutputId}
 read [0x0F 0x00 0x00 0x00] # TODO: native byte order

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/client/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/client/nukleus.rpt
@@ -1,0 +1,88 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceInputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceOutputId)
+read ([0..8]:sourceOutputRef)
+read ([0..8]:correlationId)
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceOutputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceOutputId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceInputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceInputEstId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x02]
+write ${newSourceInputEstId}
+write [0x0b] "server data"
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceInputEstId}
+read [0..4]
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/client/source.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/client/source.rpt
@@ -1,0 +1,82 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newSourceOutputNewRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceOutputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceOutputId}
+write ${newSourceOutputRef}
+write ${newCorrelationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceOutputId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceOutputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceInputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceInputEstId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+read [0x00 0x00 0x00 0x02]
+read ${sourceInputEstId}
+read [0x0b] "server data"
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceInputEstId}
+write [0x00 0x00 0x00 0x0d]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/server/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/server/nukleus.rpt
@@ -1,0 +1,84 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newTargetInputRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetInputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.throttle)}
+        option writer ${agrona:oneToOneWriter(targetInput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetInputId}
+write ${newTargetInputRef}
+write ${newCorrelationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetInputId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetInputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetOutputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ${newCorrelationId}
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${targetOutputEstId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+read [0x00 0x00 0x00 0x02]
+read ${targetOutputEstId}
+read [0x0b] "server data"
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${targetOutputEstId}
+write [0x00 0x00 0x00 0x0d]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/server/target.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.sent.end.then.received.data/server/target.rpt
@@ -1,0 +1,86 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetOutputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.buffer)}
+        option writer ${agrona:oneToOneWriter(targetInput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetInputId)
+read ([0..8]:targetInputRef)
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${targetInputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${targetInputId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetOutputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetOutputEstId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x02]
+write ${newTargetOutputEstId}
+write [0x0b] "server data"
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetOutputEstId}
+read [0..4]
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/client/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/client/nukleus.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceInputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceOutputId)
+read ([0..8]:sourceOutputRef)
+read ([0..8]:correlationId)
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceOutputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceOutputId}
+read [0x00]
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceInputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceInputEstId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceInputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/client/source.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/client/source.rpt
@@ -1,0 +1,76 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newSourceOutputNewRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceOutputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceOutputId}
+write ${newSourceOutputRef}
+write ${newCorrelationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceOutputId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceOutputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceInputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceInputEstId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceInputEstId}
+read [0x00]
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/server/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/server/nukleus.rpt
@@ -1,0 +1,78 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newTargetInputRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetInputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.throttle)}
+        option writer ${agrona:oneToOneWriter(targetInput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetInputId}
+write ${newTargetInputRef}
+write ${newCorrelationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetInputId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetInputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetOutputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ${newCorrelationId}
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${targetOutputEstId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+read [0x00 0x00 0x00 0x03]
+read ${targetOutputEstId}
+read [0x00]
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/server/target.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/client.then.server.sent.end/server/target.rpt
@@ -1,0 +1,81 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetOutputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.buffer)}
+        option writer ${agrona:oneToOneWriter(targetInput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetInputId)
+read ([0..8]:targetInputRef)
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${targetInputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${targetInputId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetOutputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetOutputEstId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetOutputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.data.multiple.frames.partial.writes/server/target.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.data.multiple.frames.partial.writes/server/target.rpt
@@ -80,8 +80,6 @@ write [0x07] "server "
 write [0x00]
 write flush
 
-write notify SECOND_WRITE_COMPLETED
-
 read [0x40 0x00 0x00 0x02]
 read ${newTargetOutputEstId}
 read [0x0F 0x00 0x00 0x00] # TODO: native byte order

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/client/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/client/nukleus.rpt
@@ -1,0 +1,85 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceInputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceOutputId)
+read ([0..8]:sourceOutputRef)
+read ([0..8]:correlationId)
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceOutputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x02]
+read ${sourceOutputId}
+read [0x0b] "client data"
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceOutputId}
+write [0x00 0x00 0x00 0x0d]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceInputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceInputEstId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceInputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/client/source.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/client/source.rpt
@@ -1,0 +1,85 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newSourceOutputNewRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceOutputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceOutputId}
+write ${newSourceOutputRef}
+write ${newCorrelationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceOutputId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x02]
+write ${newSourceOutputId}
+write [0x0b] "client data"
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceOutputId}
+read [0..4]
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceInputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceInputEstId}
+write [0x00 0x02 0x00 0x00] # TODO: native int
+write flush
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceInputEstId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/server/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/server/nukleus.rpt
@@ -1,0 +1,82 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newTargetInputRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetInputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.throttle)}
+        option writer ${agrona:oneToOneWriter(targetInput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetInputId}
+write ${newTargetInputRef}
+write ${newCorrelationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetInputId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x02]
+write ${newTargetInputId}
+write [0x0b] "client data"
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetInputId}
+read [0..4]
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetOutputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ${newCorrelationId}
+read [0x00]
+
+read [0x00 0x00 0x00 0x03]
+read ${targetOutputEstId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/server/target.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.sent.end.then.received.data/server/target.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetOutputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.buffer)}
+        option writer ${agrona:oneToOneWriter(targetInput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetInputId)
+read ([0..8]:targetInputRef)
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${targetInputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x02]
+read ${targetInputId}
+read [0x0b] "client data"
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${targetInputId}
+write [0x00 0x00 0x00 0x0d]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetOutputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x00]
+write flush
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetOutputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/client/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/client/nukleus.rpt
@@ -1,0 +1,79 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceInputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceOutputId)
+read ([0..8]:sourceOutputRef)
+read ([0..8]:correlationId)
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceOutputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceOutputId}
+read [0x00]
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceInputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceInputEstId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceInputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/client/source.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/client/source.rpt
@@ -1,0 +1,80 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newSourceOutputNewRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property sourceOutput ${nuklei.streams("tcp", "source#partition")}
+property sourceInputEst ${nuklei.streams("source", "tcp#any")}
+
+property newSourceOutputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_OUTPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceOutput.throttle)}
+        option writer ${agrona:oneToOneWriter(sourceOutput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newSourceOutputId}
+write ${newSourceOutputRef}
+write ${newCorrelationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newSourceOutputId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x03]
+write ${newSourceOutputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(sourceInputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(sourceInputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:sourceInputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${sourceInputEstId}
+write [0x00 0x02 0x00 0x00] # TODO: native int
+write flush
+
+read [0x00 0x00 0x00 0x03]
+read ${sourceInputEstId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/server/nukleus.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/server/nukleus.rpt
@@ -1,0 +1,78 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newTargetInputRef ${nuklei:newReferenceId()} # external scope
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetInputId ${nuklei:newStreamId()}
+property newCorrelationId ${nuklei:newCorrelationId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.throttle)}
+        option writer ${agrona:oneToOneWriter(targetInput.buffer)}
+connected
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetInputId}
+write ${newTargetInputRef}
+write ${newCorrelationId}
+write [0x10]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x1f 0x90]
+write [0x01] [0x04] [0x7f 0x00 0x00 0x01]
+write [0x9f 0x90]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetInputId}
+read [0..4]
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetInputId}
+write [0x00]
+write flush
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.buffer)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetOutputEstId)
+read [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+read ${newCorrelationId}
+read [0x00]
+
+write [0x40 0x00 0x00 0x02]
+write ${targetOutputEstId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+read [0x00 0x00 0x00 0x03]
+read ${targetOutputEstId}
+read [0x00]
+
+close
+closed

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/server/target.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tcp/streams/server.then.client.sent.end/server/target.rpt
@@ -1,0 +1,81 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property nuklei ${nuklei:directory("target/nukleus-itests").streamsCapacity(1024 * 1024, 64 * 1024)}
+
+property targetInput ${nuklei.streams("target", "tcp#any")}
+property targetOutputEst ${nuklei.streams("tcp", "target#partition")}
+
+property newTargetOutputEstId ${nuklei:newStreamId()}
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetInput.buffer)}
+        option writer ${agrona:oneToOneWriter(targetInput.throttle)}
+connected
+
+read [0x00 0x00 0x00 0x01]
+read ([0..8]:targetInputId)
+read ([0..8]:targetInputRef)
+read ([0..8]:correlationId)
+read [0x10]
+read ([0..8]:localAddress)
+read ([0..8]:remoteAddress)
+
+write [0x40 0x00 0x00 0x02]
+write ${targetInputId}
+write [0x00 0x02 0x00 0x00]
+write flush
+
+write notify WINDOW_UPDATED
+
+read [0x00 0x00 0x00 0x03]
+read ${targetInputId}
+read [0x00]
+
+read notify END_RECEIVED
+
+close
+closed
+
+connect await ROUTED_INPUT
+        agrona://stream/bidirectional
+        option reader ${agrona:oneToOneReader(targetOutputEst.throttle)}
+        option writer ${agrona:oneToOneWriter(targetOutputEst.buffer)}
+connected
+
+write await WINDOW_UPDATED
+
+write [0x00 0x00 0x00 0x01]
+write ${newTargetOutputEstId}
+write [0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+write ${correlationId}
+write [0x00]
+write flush
+
+read [0x40 0x00 0x00 0x02]
+read ${newTargetOutputEstId}
+read [0..4]
+
+write await END_RECEIVED
+
+write [0x00 0x00 0x00 0x03]
+write ${newTargetOutputEstId}
+write [0x00]
+write flush
+
+close
+closed

--- a/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
@@ -272,6 +272,36 @@ public class ClientIT
     @Specification({
         "${route}/output/new/nukleus",
         "${route}/output/new/controller",
+        "${streams}/client.then.server.sent.end/client/nukleus",
+        "${streams}/client.then.server.sent.end/client/source"
+    })
+    public void shouldReceiveEndAndSendEndInReply() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/nukleus",
+        "${route}/output/new/controller",
+        "${streams}/server.then.client.sent.end/client/nukleus",
+        "${streams}/server.then.client.sent.end/client/source"
+    })
+    public void shouldSendEndAndReceiveEndInReply() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/nukleus",
+        "${route}/output/new/controller",
         "${streams}/server.sent.end.then.received.data/client/nukleus",
         "${streams}/server.sent.end.then.received.data/client/source"
     })

--- a/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
@@ -268,7 +268,6 @@ public class ClientIT
         k3po.finish();
     }
 
-
     @Test
     @Specification({
         "${route}/output/new/nukleus",

--- a/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ClientIT.java
@@ -268,6 +268,37 @@ public class ClientIT
         k3po.finish();
     }
 
+
+    @Test
+    @Specification({
+        "${route}/output/new/nukleus",
+        "${route}/output/new/controller",
+        "${streams}/server.sent.end.then.received.data/client/nukleus",
+        "${streams}/server.sent.end.then.received.data/client/source"
+    })
+    public void shouldWriteDataAfterReceiveEnd() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/output/new/nukleus",
+        "${route}/output/new/controller",
+        "${streams}/client.sent.end.then.received.data/client/nukleus",
+        "${streams}/client.sent.end.then.received.data/client/source"
+    })
+    public void shouldReceiveDataAfterSendingEnd() throws Exception
+    {
+        k3po.start();
+        k3po.awaitBarrier("ROUTED_OUTPUT");
+        k3po.notifyBarrier("ROUTED_INPUT");
+        k3po.finish();
+    }
+
     @Test
     @Specification({
         "${route}/output/new/nukleus",

--- a/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ServerIT.java
@@ -227,6 +227,30 @@ public class ServerIT
     @Specification({
         "${route}/input/new/nukleus",
         "${route}/input/new/controller",
+        "${streams}/client.then.server.sent.end/server/nukleus",
+        "${streams}/client.then.server.sent.end/server/target"
+    })
+    public void shouldReceiveEndAndSendEndInReply() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/nukleus",
+        "${route}/input/new/controller",
+        "${streams}/server.then.client.sent.end/server/nukleus",
+        "${streams}/server.then.client.sent.end/server/target"
+    })
+    public void shouldSendEndAndReceiveEndInReply() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/nukleus",
+        "${route}/input/new/controller",
         "${streams}/server.sent.end.then.received.data/server/nukleus",
         "${streams}/server.sent.end.then.received.data/server/target"
     })

--- a/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ServerIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/tcp/streams/ServerIT.java
@@ -227,6 +227,30 @@ public class ServerIT
     @Specification({
         "${route}/input/new/nukleus",
         "${route}/input/new/controller",
+        "${streams}/server.sent.end.then.received.data/server/nukleus",
+        "${streams}/server.sent.end.then.received.data/server/target"
+    })
+    public void shouldReceiveDataAfterSendingEnd() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/nukleus",
+        "${route}/input/new/controller",
+        "${streams}/client.sent.end.then.received.data/server/nukleus",
+        "${streams}/client.sent.end.then.received.data/server/target"
+    })
+    public void shouldWriteDataAfterReceiveEnd() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/input/new/nukleus",
+        "${route}/input/new/controller",
         "${streams}/server.sent.data.after.end/server/nukleus",
         "${streams}/server.sent.data.after.end/server/target"
     })


### PR DESCRIPTION
New test cases are:

- client.sent.end.then.received.data
- client.then.server.sent.end/server
- server.sent.end.then.received.data
- server.then.client.sent.end

Related PR https://github.com/reaktivity/nukleus-tcp.java/pull/18 shows how they are used to test the TCP nukleus.